### PR TITLE
Replace deprecated .Site.DisqusShortname with .Site.Params.disqusShortname

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -7,7 +7,7 @@
             return;
 
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        var disqus_shortname = '{{ .Site.DisqusShortname }}';
+        var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();


### PR DESCRIPTION
## Summary

Based on the official Hugo documentation, this PR replaces the deprecated method.

## Changes

- Replaced `.Site.DisqusShortname` with `.Site.Params.disqusShortname`

## Reference

https://gohugo.io/methods/site/disqusshortname/

---

Thank you for reviewing this PR!
